### PR TITLE
More robust

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iconify"
-version = "0.1.0"
+version = "0.1.1"
 description = "Wrapper for iconify.design for Reflex"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/iconify/iconify.py
+++ b/src/iconify/iconify.py
@@ -24,6 +24,17 @@ class IconifyIcon(rx.Component):
 
     # Since this uses dynamic imports, we should use NoSSRComponent
     # is_default = True
-
+    @classmethod
+    def create(cls, *children, **props):
+        if children:
+            if len(children) == 1 and isinstance(children[0], str):
+                props["icon"] = children[0]
+            else:
+                raise AttributeError(
+                    f"Passing multiple children to Icon component is not allowed: remove positional "
+                    f"argument: {children[1:]} to fix"
+                )
+        return super().create(*children, **props)
+    
 
 icon = IconifyIcon.create


### PR DESCRIPTION
I noticed, through my use of your library, that I was trying to import the sample icons because I thought it would be the most useful approach. Although you already have something set up on a webpage, that method worked for me. However, when I went directly to the repository, I tried it and encountered an error. For a moment, I thought it might be because the icons didn’t exist in Iconify. After further investigation, though, I realized that wasn’t the case.

Your library is quite good and very robust 💪. I saw some alternatives in old posts on discussion boards and forums that were really impressive. Nevertheless, what you have here is something super useful, and I believe it has great potential. That’s why I wanted to contribute a little by adding this small validation, which simply ensures that the examples in your README are valid—since they weren’t working before, but now they can run properly with this change.

If you want to try it out, go ahead. All it does is correctly take the first argument passed to the function, determining whether it represents the icon variable or not. Moreover, if it is provided at any other time, it also validates the error.

I hope this contribution is helpful and works well, as I found your library to be extremely useful. You should consider offering a direct pip install from PyPI 📦.

```python
"""Welcome to Reflex! This file outlines the steps to create a basic app."""

import reflex as rx
from iconify import icon
from rxconfig import config


class State(rx.State):
    """The app state."""

    ...


def index() -> rx.Component:
    # Welcome Page (Index)
    return rx.container(
        rx.color_mode.button(position="top-right"),
        rx.vstack(
            rx.heading("Welcome to Reflex!", size="9"),
            rx.text(
                "Get started by editing ",
                rx.code(f"{config.app_name}/{config.app_name}.py"),
                size="5",
            ),
            rx.link(
                rx.button("Check out our docs!"),
                href="https://reflex.dev/docs/getting-started/introduction/",
                is_external=True,
            ),
            spacing="5",
            justify="center",
            min_height="85vh",
        ),
        rx.logo(),
        rx.hstack(
        # The example is here 🚧
        icon("mdi:home", color="blue", width=24),
        icon(icon="fa:arrow-right", height=32, rotate="90deg"),
        icon("simple-icons:python", h_flip=True),
        ),
    )


app = rx.App()
app.add_page(index)

```

You can see that this is working
<img width="691" alt="Screenshot 2025-03-08 at 1 37 35 a m" src="https://github.com/user-attachments/assets/7d11768b-b480-4634-871e-8d9876852470" />

